### PR TITLE
Authorise using ol 6.0 or upper

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   ],
   "peerDependencies": {
     "maplibre-gl": ">=2.0.4",
-    "ol": "~6.0"
+    "ol": ">=6.0"
   },
   "devDependencies": {
     "eslint": "^8.7.0",


### PR DESCRIPTION
This PR should avoid having errors like:

```
npm install
npm ERR! code ERESOLVE
npm ERR! ERESOLVE unable to resolve dependency tree
npm ERR! 
npm ERR! While resolving: frontend@0.0.1
npm ERR! Found: ol@6.12.0
npm ERR! node_modules/ol
npm ERR!   dev ol@"^6.9.0" from the root project
npm ERR! 
npm ERR! Could not resolve dependency:
npm ERR! peer ol@"~6.0" from @geoblocks/ol-maplibre-layer@0.0.1

```

peer dependency `~6.0` is too restrictive.