### PR TITLE
add file extensions in imports

### DIFF
--- a/src/ol-maplibre-layer.ts
+++ b/src/ol-maplibre-layer.ts
@@ -1,10 +1,10 @@
-import Layer from 'ol/layer/Layer';
-import {toDegrees} from 'ol/math';
-import {toLonLat} from 'ol/proj';
+import Layer from 'ol/layer/Layer.js';
+import {toDegrees} from 'ol/math.js';
+import {toLonLat} from 'ol/proj.js';
 
 import maplibregl from 'maplibre-gl';
-import type {FrameState} from 'ol/Map';
-import type {Options as LayerOptions} from 'ol/layer/Layer';
+import type {FrameState} from 'ol/Map.js';
+import type {Options as LayerOptions} from 'ol/layer/Layer.js';
 
 export type MapLibreLayerOptions = LayerOptions & {
   maplibreOptions: maplibregl.MapOptions;


### PR DESCRIPTION
Make lib compatible with Webpack again.
Webpack currently  throws the following error:

```
BREAKING CHANGE: The request 'ol/layer/Layer' failed to resolve only because it was resolved as fully specified
(probably because the origin is strict EcmaScript Module, e. g. a module with javascript mimetype, a '*.mjs' file, or a '*.js' file where the package.json contains '"type": "module"').
The extension in the request is mandatory for it to be fully specified.
```