### PR TITLE
ensure compatibility with Node.js

### DIFF
--- a/src/MapLibreLayer.ts
+++ b/src/MapLibreLayer.ts
@@ -1,14 +1,14 @@
 import {Map as MapLibreMap} from 'maplibre-gl';
-import type {MapOptions, QueryRenderedFeaturesOptions } from 'maplibre-gl';
+import type {MapOptions, QueryRenderedFeaturesOptions} from 'maplibre-gl';
 import type {Map} from 'ol';
 import Layer from 'ol/layer/Layer.js';
 import type {Options as LayerOptions} from 'ol/layer/Layer.js';
-import type {EventsKey} from 'ol/events';
-import BaseEvent from 'ol/events/Event';
-import {unByKey} from 'ol/Observable';
-import {Source} from 'ol/source';
-import MapLibreLayerRenderer from './MapLibreLayerRenderer';
-import getMapLibreAttributions from './getMapLibreAttributions';
+import type {EventsKey} from 'ol/events.js';
+import BaseEvent from 'ol/events/Event.js';
+import {unByKey} from 'ol/Observable.js';
+import {Source} from 'ol/source.js';
+import MapLibreLayerRenderer from './MapLibreLayerRenderer.js';
+import getMapLibreAttributions from './getMapLibreAttributions.js';
 
 export type MapLibreOptions = Omit<MapOptions, 'container'>;
 

--- a/src/MapLibreLayerRenderer.ts
+++ b/src/MapLibreLayerRenderer.ts
@@ -1,17 +1,17 @@
 import type {MapGeoJSONFeature} from 'maplibre-gl';
-import type {QueryRenderedFeaturesOptions } from 'maplibre-gl';
-import type {FrameState} from 'ol/Map';
-import {toDegrees} from 'ol/math';
-import {toLonLat} from 'ol/proj';
-import LayerRenderer from 'ol/renderer/Layer';
-import GeoJSON from 'ol/format/GeoJSON';
-import type {Coordinate} from 'ol/coordinate';
-import type {FeatureCallback} from 'ol/renderer/vector';
+import type {QueryRenderedFeaturesOptions} from 'maplibre-gl';
+import type {FrameState} from 'ol/Map.js';
+import {toDegrees} from 'ol/math.js';
+import {toLonLat} from 'ol/proj.js';
+import LayerRenderer from 'ol/renderer/Layer.js';
+import GeoJSON from 'ol/format/GeoJSON.js';
+import type {Coordinate} from 'ol/coordinate.js';
+import type {FeatureCallback} from 'ol/renderer/vector.js';
 import type {Feature} from 'ol';
-import type {Geometry} from 'ol/geom';
-import {SimpleGeometry} from 'ol/geom';
-import type {Pixel} from 'ol/pixel';
-import type MapLibreLayer from './MapLibreLayer';
+import type {Geometry} from 'ol/geom.js';
+import {SimpleGeometry} from 'ol/geom.js';
+import type {Pixel} from 'ol/pixel.js';
+import type MapLibreLayer from './MapLibreLayer.js';
 
 const VECTOR_TILE_FEATURE_PROPERTY = 'vectorTileFeature';
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,3 @@
-export {default as MapLibreLayer} from './MapLibreLayer';
-export {default as MapLibreLayerRenderer} from './MapLibreLayerRenderer';
-export {default as getMapLibreAttributions} from './getMapLibreAttributions';
+export {default as MapLibreLayer} from './MapLibreLayer.js';
+export {default as MapLibreLayerRenderer} from './MapLibreLayerRenderer.js';
+export {default as getMapLibreAttributions} from './getMapLibreAttributions.js';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,12 +1,12 @@
 {
   "compilerOptions": {
     "target": "ES2022",
-    "module": "ES2022",
+    "module": "nodenext",
     "lib": ["es2023", "dom"],
     "baseUrl": "./",
     "skipLibCheck": true,
 
-    "moduleResolution": "Node",
+    "moduleResolution": "nodenext",
     "outDir": "./lib",
     "inlineSourceMap": true,
 


### PR DESCRIPTION
See https://www.typescriptlang.org/docs/handbook/modules/reference.html#node16-nodenext

```
- node16 and nodenext are the only correct module options for all apps and libraries that are intended to run in Node.js v12 or later, whether they use ES modules or not.
```