### PR TITLE
Fix types path in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "CHANGES.md"
   ],
   "module": "lib/index.js",
-  "types": "lib/types/index.d.ts",
+  "types": "lib/index.d.ts",
   "targets": {
     "demo": {
       "source": "examples/demo.html",


### PR DESCRIPTION
Type definition file ("types" in package.json) points to a non-existent path. This pull request simply corrects the path so that users of ol-maplibre-layer with a type-checking project setup can use the library.