### PR TITLE
Wait for MapLibre ready event to set renderer as ready

### DIFF
--- a/src/MapLibreLayer.ts
+++ b/src/MapLibreLayer.ts
@@ -111,6 +111,7 @@ export default class MapLibreLayer extends Layer {
 
     this.mapLibreMap.once('load', () => {
       this.loaded = true;
+      this.getRenderer().ready = true
       this.dispatchEvent(new BaseEvent('load'));
     });
   }

--- a/src/MapLibreLayerRenderer.ts
+++ b/src/MapLibreLayerRenderer.ts
@@ -34,6 +34,7 @@ export default class MapLibreLayerRenderer extends LayerRenderer<MapLibreLayer> 
   constructor(layer: MapLibreLayer, translateZoom: MapLibreLayerTranslateZoomFunction | undefined) {
     super(layer)
     this.translateZoom = translateZoom
+    this.ready = false
   }
 
   getFeaturesAtCoordinate(


### PR DESCRIPTION
OpenLayers will fire `rendercomplete` event only when MapLibre is done rendering the layer